### PR TITLE
chore: Prettier 설정 및 PR 템플릿 추가

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+## 작업 개요
+
+- 기본 배포용 구조 세팅 및 전역 스타일 적용
+
+---
+
+## 작업 상세 내용
+
+- [x] 글로벌 CSS 파일 설정
+- [x] 기본 레이아웃 작성 (Header, Footer)
+
+---
+
+## 수정한 파일
+
+- `src/app/layout.tsx`
+- `src/styles/global.css`
+
+## 새로 작성한 파일
+
+- `src/components/Header.tsx`
+- `src/components/Footer.tsx`
+
+---
+
+## 기타 참고 사항
+
+- favicon은 임시 파일 사용 중이며, 추후 교체 예정
+- (UI 변경 시 스크린샷 첨부 권장)
+
+---
+
+## 작업 스크린샷
+
+![UI Preview](https://github.com/username/repo/assets/이미지링크)

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,22 @@
+{
+   "arrowParens": "always",
+   "bracketSameLine": false,
+   "bracketSpacing": true,
+   "semi": true,
+   "experimentalTernaries": false,
+   "singleQuote": false,
+   "jsxSingleQuote": false,
+   "quoteProps": "as-needed",
+   "trailingComma": "all",
+   "singleAttributePerLine": false,
+   "htmlWhitespaceSensitivity": "css",
+   "vueIndentScriptAndStyle": false,
+   "proseWrap": "preserve",
+   "insertPragma": false,
+   "printWidth": 80,
+   "requirePragma": false,
+   "tabWidth": 3,
+   "useTabs": false,
+   "embeddedLanguageFormatting": "auto",
+   "plugins": ["prettier-plugin-tailwindcss"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnType": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "15.5.2",
+        "prettier-plugin-tailwindcss": "^0.6.14",
         "tailwindcss": "^4",
         "typescript": "^5"
       }
@@ -5006,6 +5007,110 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.6.14",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.14.tgz",
+      "integrity": "sha512-pi2e/+ZygeIqntN+vC573BcW5Cve8zUB0SSAGxqpB4f96boZF4M3phPVoOFCeypwkpRYdi7+jQ5YJJUwrkGUAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "peerDependencies": {
+        "@ianvs/prettier-plugin-sort-imports": "*",
+        "@prettier/plugin-hermes": "*",
+        "@prettier/plugin-oxc": "*",
+        "@prettier/plugin-pug": "*",
+        "@shopify/prettier-plugin-liquid": "*",
+        "@trivago/prettier-plugin-sort-imports": "*",
+        "@zackad/prettier-plugin-twig": "*",
+        "prettier": "^3.0",
+        "prettier-plugin-astro": "*",
+        "prettier-plugin-css-order": "*",
+        "prettier-plugin-import-sort": "*",
+        "prettier-plugin-jsdoc": "*",
+        "prettier-plugin-marko": "*",
+        "prettier-plugin-multiline-arrays": "*",
+        "prettier-plugin-organize-attributes": "*",
+        "prettier-plugin-organize-imports": "*",
+        "prettier-plugin-sort-imports": "*",
+        "prettier-plugin-style-order": "*",
+        "prettier-plugin-svelte": "*"
+      },
+      "peerDependenciesMeta": {
+        "@ianvs/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@prettier/plugin-hermes": {
+          "optional": true
+        },
+        "@prettier/plugin-oxc": {
+          "optional": true
+        },
+        "@prettier/plugin-pug": {
+          "optional": true
+        },
+        "@shopify/prettier-plugin-liquid": {
+          "optional": true
+        },
+        "@trivago/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@zackad/prettier-plugin-twig": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        },
+        "prettier-plugin-css-order": {
+          "optional": true
+        },
+        "prettier-plugin-import-sort": {
+          "optional": true
+        },
+        "prettier-plugin-jsdoc": {
+          "optional": true
+        },
+        "prettier-plugin-marko": {
+          "optional": true
+        },
+        "prettier-plugin-multiline-arrays": {
+          "optional": true
+        },
+        "prettier-plugin-organize-attributes": {
+          "optional": true
+        },
+        "prettier-plugin-organize-imports": {
+          "optional": true
+        },
+        "prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "prettier-plugin-style-order": {
+          "optional": true
+        },
+        "prettier-plugin-svelte": {
+          "optional": true
+        }
       }
     },
     "node_modules/prop-types": {

--- a/package.json
+++ b/package.json
@@ -9,19 +9,20 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "next": "15.5.2",
     "react": "19.1.0",
-    "react-dom": "19.1.0",
-    "next": "15.5.2"
+    "react-dom": "19.1.0"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@eslint/eslintrc": "^3",
+    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.5.2",
-    "@eslint/eslintrc": "^3"
+    "prettier-plugin-tailwindcss": "^0.6.14",
+    "tailwindcss": "^4",
+    "typescript": "^5"
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,10 @@
 export default function Home() {
-  return <div>이담 건축</div>;
+   return (
+      <div>
+         <div>
+            <p>이담 건축에 오신 여러분들을 환영합니다.</p>
+            <span>.prettierrc 적용 완료</span>
+         </div>
+      </div>
+   );
 }


### PR DESCRIPTION
## 작업 개요
- Prettier 코드 포맷터와 PR 템플릿을 프로젝트에 추가하여 코드 스타일 일관성을 유지

---

## 작업 상세 내용
- [x] Prettier 설정 파일(.prettierrc) 추가  
- [x] Prettier TailwindCSS 플러그인 적용  
- [x] package.json / package-lock.json에 Prettier 의존성 추가  
- [x] page.tsx 파일 Prettier 포맷 적용  
- [x] VSCode 설정(.vscode) 추가  
- [x] PR 템플릿(.github/pull_request_template.md) 생성 

---

## 수정한 파일
- package.json  
- package-lock.json  
- src/app/page.tsx  

## 새로 작성한 파일
- .prettierrc  
- .vscode/  
- .github/pull_request_template.md  

---

## 기타 참고 사항
- 앞으로 모든 PR 작성 시 템플릿 활용 예정  


