### PR TITLE
feat: Work 페이지에 목록/갤러리 보기 전환 기능 추가 및 컴포넌트 리팩토링

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,11 @@ const nextConfig: NextConfig = {
    images: {
       domains: ["res.cloudinary.com"],
    },
+   logging: {
+      fetches: {
+         fullUrl: true,
+      },
+   },
 };
 
 export default nextConfig;

--- a/src/api/create-project.action.ts
+++ b/src/api/create-project.action.ts
@@ -2,6 +2,7 @@
 
 import { database } from "@/lib/firebase/firebase";
 import { ref, push, set } from "firebase/database";
+import { revalidatePath } from "next/cache";
 
 interface CreateProjectResult {
    success: boolean;
@@ -79,6 +80,10 @@ export default async function createProject(
 
       // Firebase에 데이터 저장
       await set(newProjectRef, projectData);
+
+      // 캐시 무효화
+      revalidatePath("/work"); // /work 페이지 전체 다시 fetch
+      revalidatePath("/"); // 홈에서 ProjectsList 쓰면 같이 리프레시 가능
 
       return {
          success: true,

--- a/src/api/get-random-projects.action.ts
+++ b/src/api/get-random-projects.action.ts
@@ -2,10 +2,7 @@
 
 import { Project } from "@/lib/types";
 import getProjects from "./get-projects.action";
-import { delay } from "@/utils";
-
 export async function getRandomProjects(excludeId: string): Promise<Project[]> {
-   await delay(1000);
    const result = await getProjects();
 
    if (!result.success || !result.data) return [];

--- a/src/app/(with-same-header)/work/page.tsx
+++ b/src/app/(with-same-header)/work/page.tsx
@@ -1,10 +1,39 @@
 import PageTitle from "@/components/common/PageTitle";
+import CompletedWorksGrid from "@/components/domains/work/CompletedWorksGrid";
+import CompletedWorksList from "@/components/domains/work/CompletedWorksList";
+import CompletedWorksToggle from "@/components/domains/work/CompletedWorksToggle";
 import PageLayout from "@/components/layout/PageLayout";
+import { redirect } from "next/navigation";
 
-export default function WorkPage() {
+export default async function WorkPage({
+   searchParams,
+}: {
+   searchParams: Promise<{ view: string }>;
+}) {
+   const { view } = await searchParams;
+
+   if (!view) {
+      redirect("?view=list");
+   }
+
+   let content;
+   switch (view) {
+      case "grid":
+         content = <CompletedWorksGrid />;
+         break;
+      case "list":
+         content = <CompletedWorksList />;
+         break;
+      default:
+         redirect("?tab=1");
+   }
    return (
       <PageLayout>
          <PageTitle title="완공 작품" />
+         <div>
+            <CompletedWorksToggle />
+            {content}
+         </div>
       </PageLayout>
    );
 }

--- a/src/components/common/ProjectRow.tsx
+++ b/src/components/common/ProjectRow.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useIntersection } from "@/hooks";
+import { Project } from "@/lib/types";
+import { revealStyle } from "@/utils";
+import Image from "next/image";
+import Link from "next/link";
+
+export default function ProjectRow(props: Project) {
+   const { id, title, year, mainImage, usage, type } = props;
+   const { ref: sectionRef, isVisible } = useIntersection();
+
+   return (
+      <div ref={sectionRef} className="lg:w-8/10">
+         <Link
+            href={`/work/${id}`}
+            style={revealStyle(isVisible, 1)}
+            className="group border-line-black-10 flex justify-between gap-6 border-b py-4 break-keep"
+         >
+            <div className="flex-wrap sm:flex sm:gap-4 md:gap-8 lg:gap-12">
+               <span className="text-14-medium sm:text-16-medium md:text-18-medium lg:text-20-regular">
+                  {year}
+               </span>
+               <h4 className="text-20-medium sm:text-24-medium md:text-28-medium lg:text-30-medium">
+                  {title}
+               </h4>
+               <span className="text-14-medium sm:text-16-medium md:text-18-medium lg:text-20-medium relative hidden h-fit w-fit text-nowrap after:absolute after:bottom-0 after:left-0 after:h-[1px] after:w-full after:origin-right after:scale-x-0 after:bg-current after:transition-transform after:duration-300 group-hover:after:origin-left group-hover:after:scale-x-100 lg:block">
+                  {usage} · {type}
+               </span>
+            </div>
+            <div className="w-2/8">
+               <div className="overflow-hidden">
+                  <Image
+                     src={mainImage}
+                     alt={`${title}-Image`}
+                     width={0} // Next.js에서 required, 0 넣고
+                     height={0}
+                     sizes="100vw" // 뷰포트 기준으로 꽉 채움
+                     className="h-auto w-full transition-transform duration-300 ease-in-out group-hover:scale-105"
+                  />
+               </div>
+            </div>
+         </Link>
+      </div>
+   );
+}

--- a/src/components/common/ProjectsList.tsx
+++ b/src/components/common/ProjectsList.tsx
@@ -1,7 +1,7 @@
 import getProjects from "@/api/get-projects.action";
 import ProjectCard from "./ProjectCard";
 
-export default async function ProjectsList() {
+export default async function ProjectsList({ limit }: { limit?: number }) {
    const { success, data } = await getProjects();
    if (!success || !data)
       return (
@@ -9,10 +9,11 @@ export default async function ProjectsList() {
             갤러리 데이터를 불러올 수 없습니다.
          </p>
       );
-   const limitedProjects = data.slice(0, 4);
+   const projects = limit ? data.slice(0, limit) : data;
+
    return (
       <div className="grid grid-cols-1 gap-8 pt-3 md:grid-cols-2 md:gap-x-5 md:gap-y-16 md:pt-5">
-         {limitedProjects.map((project) => (
+         {projects.map((project) => (
             <ProjectCard key={project.id} {...project} />
          ))}
       </div>

--- a/src/components/domains/root/WorkBodySection.tsx
+++ b/src/components/domains/root/WorkBodySection.tsx
@@ -3,19 +3,19 @@ import ProjectCardSkeleton from "@/components/skeleton/ProjectCardSkeleton";
 import SkeletonLayout from "@/components/skeleton/SkeletonLayout";
 import { Suspense } from "react";
 
-export default function WorkBodySection() {
+export default function WorkBodySection({ limit }: { limit?: number }) {
    return (
       <Suspense
          fallback={
             <div className="grid grid-cols-1 gap-8 pt-3 md:grid-cols-2 md:gap-x-5 md:gap-y-16 md:pt-5">
                <SkeletonLayout
-                  count={4}
+                  count={limit ?? 6}
                   SkeletonComponent={ProjectCardSkeleton}
                />
             </div>
          }
       >
-         <ProjectsList />
+         <ProjectsList limit={limit} />
       </Suspense>
    );
 }

--- a/src/components/domains/root/WorkSection.tsx
+++ b/src/components/domains/root/WorkSection.tsx
@@ -6,7 +6,7 @@ export default function WorkSection() {
    return (
       <DefaultLayout>
          <WorkHeaderSection />
-         <WorkBodySection />
+         <WorkBodySection limit={6} />
       </DefaultLayout>
    );
 }

--- a/src/components/domains/work/CompletedProjectsList.tsx
+++ b/src/components/domains/work/CompletedProjectsList.tsx
@@ -1,0 +1,19 @@
+import getProjects from "@/api/get-projects.action";
+import ProjectRow from "@/components/common/ProjectRow";
+
+export default async function CompletedProjectsList() {
+   const { success, data } = await getProjects();
+   if (!success || !data)
+      return (
+         <p className="text-16-regular md:text-18-regular py-10 text-center">
+            갤러리 데이터를 불러올 수 없습니다.
+         </p>
+      );
+   return (
+      <div className="lg:flex lg:flex-col lg:items-end">
+         {data.map((project) => (
+            <ProjectRow key={project.id} {...project} />
+         ))}
+      </div>
+   );
+}

--- a/src/components/domains/work/CompletedWorksGrid.tsx
+++ b/src/components/domains/work/CompletedWorksGrid.tsx
@@ -1,0 +1,9 @@
+import WorkBodySection from "../root/WorkBodySection";
+
+export default function CompletedWorksGrid() {
+   return (
+      <div className="px-4">
+         <WorkBodySection />
+      </div>
+   );
+}

--- a/src/components/domains/work/CompletedWorksList.tsx
+++ b/src/components/domains/work/CompletedWorksList.tsx
@@ -1,0 +1,9 @@
+import CompletedWorksListSection from "./CompletedWorksListSection";
+
+export default function CompletedWorksList() {
+   return (
+      <div className="px-4 pt-3 md:pt-5">
+         <CompletedWorksListSection />
+      </div>
+   );
+}

--- a/src/components/domains/work/CompletedWorksListSection.tsx
+++ b/src/components/domains/work/CompletedWorksListSection.tsx
@@ -1,0 +1,21 @@
+import { Suspense } from "react";
+import CompletedProjectsList from "./CompletedProjectsList";
+import SkeletonLayout from "@/components/skeleton/SkeletonLayout";
+import ProjectRowSkeleton from "@/components/skeleton/ProjectRowSkeleton";
+
+export default function CompletedWorksListSection() {
+   return (
+      <Suspense
+         fallback={
+            <div className="lg:flex lg:flex-col lg:items-end">
+               <SkeletonLayout
+                  count={6}
+                  SkeletonComponent={ProjectRowSkeleton}
+               />
+            </div>
+         }
+      >
+         <CompletedProjectsList />
+      </Suspense>
+   );
+}

--- a/src/components/domains/work/CompletedWorksSection.tsx
+++ b/src/components/domains/work/CompletedWorksSection.tsx
@@ -1,0 +1,20 @@
+import CompletedWorksGrid from "./CompletedWorksGrid";
+import CompletedWorksList from "./CompletedWorksList";
+import CompletedWorksToggle from "./CompletedWorksToggle";
+
+export default async function CompletedWorksSection({
+   view,
+}: {
+   view: string;
+}) {
+   console.log(view);
+   let content;
+   if (view === "grid") content = <CompletedWorksGrid />;
+   else content = <CompletedWorksList />;
+   return (
+      <div>
+         <CompletedWorksToggle />
+         {content}
+      </div>
+   );
+}

--- a/src/components/domains/work/CompletedWorksToggle.tsx
+++ b/src/components/domains/work/CompletedWorksToggle.tsx
@@ -1,0 +1,41 @@
+"use client";
+import { useIntersection } from "@/hooks";
+import { revealStyle } from "@/utils";
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
+
+export default function CompletedWorksToggle() {
+   const router = useRouter();
+   const searchParams = useSearchParams();
+   const pathname = usePathname(); // 현재 경로 가져오기
+   const viewType = searchParams.get("view") || "grid";
+
+   const handleChangeView = (view: "grid" | "list") => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set("view", view);
+      router.push(`${pathname}?${params.toString()}`);
+   };
+   const { ref: sectionRef, isVisible } = useIntersection();
+
+   return (
+      <div
+         ref={sectionRef}
+         style={revealStyle(isVisible, 1)}
+         className="border-line-black-10 border-t px-4 pt-4"
+      >
+         <div className="text-14-medium sm:text-16-medium lg:text-18-medium flex gap-1.5 sm:gap-2 lg:gap-2.5">
+            <button
+               onClick={() => handleChangeView("grid")}
+               className={viewType === "grid" ? "text-black" : "text-black/60"}
+            >
+               갤러리 형태
+            </button>
+            <button
+               onClick={() => handleChangeView("list")}
+               className={viewType === "list" ? "text-black" : "text-black/60"}
+            >
+               목록 형태
+            </button>
+         </div>
+      </div>
+   );
+}

--- a/src/components/skeleton/ProjectRowSkeleton.tsx
+++ b/src/components/skeleton/ProjectRowSkeleton.tsx
@@ -1,0 +1,33 @@
+import Image from "next/image";
+
+export default function ProjectRowSkeleton() {
+   return (
+      <div className="lg:w-8/10">
+         <div className="group border-line-black-10 flex justify-between gap-6 border-b py-4 break-keep">
+            {/* 왼쪽 텍스트 영역 */}
+            <div className="flex flex-col flex-wrap gap-1 sm:flex-row sm:gap-4 md:gap-8 lg:gap-12">
+               {/* year */}
+               <div className="subtle-pulse h-4 w-10 bg-black/70 sm:h-6 sm:w-12 md:h-7 md:w-14 lg:h-8 lg:w-16" />
+               {/* title */}
+               <div className="subtle-pulse h-6 w-28 bg-black/80 sm:h-7 sm:w-36 md:h-8 md:w-44 lg:h-9 lg:w-52" />
+               {/* usage · type */}
+               <div className="subtle-pulse relative hidden h-5 w-20 bg-black/60 lg:block" />
+            </div>
+
+            {/* 오른쪽 이미지 영역 */}
+            <div className="w-2/8">
+               <div className="overflow-hidden">
+                  <Image
+                     src="https://res.cloudinary.com/dmtmnadim/image/upload/v1757934745/skeleton_rn1c1r.jpg"
+                     alt="skeletonImage"
+                     width={0}
+                     height={0}
+                     sizes="100vw"
+                     className="h-auto w-full"
+                  />
+               </div>
+            </div>
+         </div>
+      </div>
+   );
+}


### PR DESCRIPTION
## 작업 개요
- Work 페이지에서 프로젝트를 **목록 보기 / 갤러리 보기**로 전환할 수 있는 기능 생성
- UI 생성 및 관련 컴포넌트 리팩토링 진행  

---

## 작업 상세 내용
- [x] 목록/갤러리 전환 토글(`CompletedWorksToggle`) 추가  
- [x] 목록형 컴포넌트(`ProjectRow`, `CompletedWorksList`) 작성  
- [x] 갤러리형 컴포넌트(`CompletedWorksGrid`) 작성  
- [x] 스켈레톤 UI(`ProjectRowSkeleton`) 추가  
- [x] `getProjects` API 응답 정렬 로직 개선 (최신순) 

---

## 수정한 파일
- `src/api/get-projects.action.ts`  
- `src/components/common/ProjectsList.tsx`  
- `src/components/domains/root/WorkBodySection.tsx`  
- `src/components/domains/root/WorkSection.tsx`  

## 새로 작성한 파일
- `src/components/domains/work/CompletedProjectsList.tsx`  
- `src/components/domains/work/CompletedWorksGrid.tsx`  
- `src/components/domains/work/CompletedWorksList.tsx`  
- `src/components/domains/work/CompletedWorksListSection.tsx`  
- `src/components/domains/work/CompletedWorksSection.tsx`  
- `src/components/domains/work/CompletedWorksToggle.tsx`  
- `src/components/domains/work/ProjectRow.tsx`  
- `src/components/skeleton/ProjectRowSkeleton.tsx`  

---

## 기타 참고 사항
- 스켈레톤 UI는 프로젝트 로딩 상태에서만 표시됨  
---

## 작업 스크린샷
<img width="2184" height="2102" alt="image" src="https://github.com/user-attachments/assets/4abc8c3f-36b0-4e2f-bc17-24a0b6237cad" />
<img width="2184" height="2102" alt="image" src="https://github.com/user-attachments/assets/a1676d07-4f23-406f-8643-9840894c5d7c" />
