### PR TITLE
style: VisualCard에 black/30 오버레이 추가

### DIFF
--- a/src/components/common/VisualCard.tsx
+++ b/src/components/common/VisualCard.tsx
@@ -8,7 +8,7 @@ export default function VisualCard({ visualImage }: { visualImage: string }) {
    const { ref, isVisible } = useScaleIntersection();
 
    return (
-      <div ref={ref} className="mb-4 overflow-hidden">
+      <div ref={ref} className="relative mb-4 overflow-hidden">
          <motion.div
             animate={{ scale: isVisible ? 1.05 : 1 }}
             transition={{ duration: 0.7, ease: "easeOut" }}
@@ -22,6 +22,9 @@ export default function VisualCard({ visualImage }: { visualImage: string }) {
                className="h-auto w-full"
             />
          </motion.div>
+
+         {/* 블랙 오버레이 */}
+         <div className="pointer-events-none absolute inset-0 bg-black/30" />
       </div>
    );
 }


### PR DESCRIPTION
## 작업 개요

- VisualCard 컴포넌트에 블랙 오버레이(`bg-black/30`)를 추가하여 이미지 위 텍스트 및 UI 요소의 가독성을 향상시킴

---

## 작업 상세 내용
- [x] `VisualCard.tsx`에 relative 컨테이너 및 absolute 오버레이 추가
- [x] 이미지 위에 `bg-black/30` 레이어 적용
- [x] 기존 스케일 애니메이션 동작과 충돌 없는지 확인 완료

---

## 수정한 파일
- modified: `src/components/common/VisualCard.tsx`
