### PR TITLE
fix: ChatBot 모바일 모달 오픈 시 스크롤 차단 기능 추가

### DIFF
--- a/src/components/common/ChatBot.tsx
+++ b/src/components/common/ChatBot.tsx
@@ -41,6 +41,27 @@ export default function ChatBot() {
       }
    }, [isVisible]);
 
+   useEffect(() => {
+      if (typeof window === "undefined") return;
+
+      const handleScrollLock = () => {
+         const isMobile = window.innerWidth < 768;
+         if (isOpen && isMobile) {
+            document.body.classList.add("overflow-hidden");
+         } else {
+            document.body.classList.remove("overflow-hidden");
+         }
+      };
+
+      handleScrollLock(); // 초기 실행
+      window.addEventListener("resize", handleScrollLock);
+
+      return () => {
+         document.body.classList.remove("overflow-hidden");
+         window.removeEventListener("resize", handleScrollLock);
+      };
+   }, [isOpen]);
+
    useClickOutside(chatRef, (event: MouseEvent) => {
       if (buttonRef.current?.contains(event.target as Node)) return;
       setIsOpen(false);


### PR DESCRIPTION
## 작업 개요

- ChatBot 모바일 모달 오픈 시 전체 스크롤이 활성화되는 문제 해결
- 모바일 환경에서 모달이 열리면 화면 스크롤을 차단하도록 기능 추가

---

## 작업 상세 내용

- [x] `useEffect` 훅을 추가하여 모바일(`window.innerWidth < 768`) 환경에서만 `body`에 `overflow-hidden` 적용
- [x] PC 환경에서는 스크롤 차단이 적용되지 않도록 분기 처리

---

## 수정한 파일
- `src/components/common/ChatBot.tsx`



---

## 기타 참고 사항
- 접근성을 고려하여 PC 환경에서는 정상 스크롤 유지

