### PR TITLE
feat: 카카오톡 오픈채팅방 링크 추가 및 상담 안내 규칙 강화

### DIFF
--- a/src/api/create-chat.action.ts
+++ b/src/api/create-chat.action.ts
@@ -1,57 +1,59 @@
 // src/lib/api/sendChatMessage.ts
 "use server";
 
-import { companyData, qaList,  } from "@/constants";
+import { companyData, qaList } from "@/constants";
 
 interface Message {
-  role: "user" | "assistant" | "system";
-  content: string;
+   role: "user" | "assistant" | "system";
+   content: string;
 }
 
 interface SendChatMessageResult {
-  success: boolean;
-  message: string | null;
-  error?: string;
+   success: boolean;
+   message: string | null;
+   error?: string;
 }
 
 // 패턴 매칭
 function findQuickAnswer(userMessage: string): string | null {
-  const message = userMessage.toLowerCase().replace(/\s/g, "");
-  for (const item of qaList) {
-    const isMatch = item.patterns.some((pattern) =>
-      message.includes(pattern.toLowerCase())
-    );
-    if (isMatch) return item.response;
-  }
-  return null;
+   const message = userMessage.toLowerCase().replace(/\s/g, "");
+   for (const item of qaList) {
+      const isMatch = item.patterns.some((pattern) =>
+         message.includes(pattern.toLowerCase()),
+      );
+      if (isMatch) return item.response;
+   }
+   return null;
 }
 
 // 메인 함수
 export async function sendChatMessage(
-  messages: Message[]
+   messages: Message[],
 ): Promise<SendChatMessageResult> {
-  try {
-    const lastUserMessage = messages[messages.length - 1]?.content || "";
+   try {
+      const lastUserMessage = messages[messages.length - 1]?.content || "";
 
-    // 1단계: FAQ 우선
-    const quickAnswer = findQuickAnswer(lastUserMessage);
-    if (quickAnswer) {
-      return { success: true, message: quickAnswer };
-    }
+      // 1단계: FAQ 우선
+      const quickAnswer = findQuickAnswer(lastUserMessage);
+      if (quickAnswer) {
+         return { success: true, message: quickAnswer };
+      }
 
-    // 2단계: GPT 호출
-    const response = await fetch("https://api.openai.com/v1/chat/completions", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        model: "gpt-3.5-turbo",
-        messages: [
-          {
-            role: "system",
-            content: `
+      // 2단계: GPT 호출
+      const response = await fetch(
+         "https://api.openai.com/v1/chat/completions",
+         {
+            method: "POST",
+            headers: {
+               Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+               "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+               model: "gpt-3.5-turbo",
+               messages: [
+                  {
+                     role: "system",
+                     content: `
 당신은 ${companyData.name}의 전문 건축 상담사입니다.
 
 규칙:
@@ -65,32 +67,34 @@ export async function sendChatMessage(
 - 그 외의 질문은 먼저 ${qaList}를 참고해서 대답하세요.
 - 대표, 설립 연도, 내부 인원 등 공개하지 않은 정보는 "공개하지 않았습니다."라고만 답하세요.
 - FAQ에 없는 질문은 건축 전문가답게 설명하되, 모르는 것은 절대 지어내지 말고 "정확한 정보는 상담 시 안내드립니다."라고 답하세요.
+- 사용자가 상담 일정을 직접 잡아달라거나, 자동으로 예약되는 뉘앙스로 요청하는 경우에는 상담은 연락을 주시거나 카톡 오픈 채팅방, 또는 문의하기를 통해 이용해 주세요. 라고 반드시 안내한다.
 - 불필요한 이모티콘은 사용하지 마세요.
             `,
-          },
-          ...messages,
-        ],
-        max_tokens: 700,
-        temperature: 0.4,
-      }),
-    });
+                  },
+                  ...messages,
+               ],
+               max_tokens: 700,
+               temperature: 0.4,
+            }),
+         },
+      );
 
-    if (!response.ok) throw new Error(`OpenAI API error: ${response.status}`);
+      if (!response.ok) throw new Error(`OpenAI API error: ${response.status}`);
 
-    const data = await response.json();
-    let aiMessage = data.choices[0].message.content;
+      const data = await response.json();
+      let aiMessage = data.choices[0].message.content;
 
-    if (!aiMessage.includes(companyData.phone) && aiMessage.length < 200) {
-      aiMessage += `\n\n더 자세한 상담은 ${companyData.phone} 으로 문의해주세요.`;
-    }
+      if (!aiMessage.includes(companyData.phone) && aiMessage.length < 200) {
+         aiMessage += `\n\n더 자세한 상담은 ${companyData.phone} 으로 문의해주세요.`;
+      }
 
-    return { success: true, message: aiMessage };
-  } catch (error) {
-    console.error("sendChatMessage Error:", error);
-    return {
-      success: false,
-      message: null,
-      error: `상담 서비스에 문제가 발생했습니다.\n전화: ${companyData.phone}\n운영시간: ${companyData.hours}`,
-    };
-  }
+      return { success: true, message: aiMessage };
+   } catch (error) {
+      console.error("sendChatMessage Error:", error);
+      return {
+         success: false,
+         message: null,
+         error: `상담 서비스에 문제가 발생했습니다.\n전화: ${companyData.phone}\n운영시간: ${companyData.hours}`,
+      };
+   }
 }

--- a/src/app/(with-same-header)/contact/page.tsx
+++ b/src/app/(with-same-header)/contact/page.tsx
@@ -31,20 +31,20 @@ export default function ContactPage() {
                         인스타그램
                      </a>
                      <a
+                        href="https://open.kakao.com/o/sWS3f0Th"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="link-underline"
+                     >
+                        카카오톡
+                     </a>
+                     <a
                         href="https://www.youtube.com/"
                         target="_blank"
                         rel="noopener noreferrer"
                         className="link-underline"
                      >
                         유튜브
-                     </a>
-                     <a
-                        href="https://github.com/az0319h/idamstudio-web"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="link-underline"
-                     >
-                        깃허브
                      </a>
                   </div>
                </li>

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -64,23 +64,23 @@ export default function Footer() {
                   </li>
                   <li className="border-line-black-10 hover:border-line-white-15 group border-b transition-all duration-300 hover:bg-black">
                      <a
+                        href="https://open.kakao.com/o/sWS3f0Th"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="group-hover:px-1 group-hover:text-white group-hover:transition-all group-hover:duration-300"
+                     >
+                        카카오톡
+                        <GoArrowUpRight size={22} className="md:size-6" />
+                     </a>
+                  </li>
+                  <li className="border-line-black-10 hover:border-line-white-15 group border-b transition-all duration-300 hover:bg-black">
+                     <a
                         href="https://www.youtube.com/"
                         target="_blank"
                         rel="noopener noreferrer"
                         className="group-hover:px-1 group-hover:text-white group-hover:transition-all group-hover:duration-300"
                      >
                         유튜브
-                        <GoArrowUpRight size={22} className="md:size-6" />
-                     </a>
-                  </li>
-                  <li className="border-line-black-10 hover:border-line-white-15 group border-b transition-all duration-300 hover:bg-black">
-                     <a
-                        href="https://github.com/az0319h/idamstudio-web"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="group-hover:px-1 group-hover:text-white group-hover:transition-all group-hover:duration-300"
-                     >
-                        깃허브
                         <GoArrowUpRight size={22} className="md:size-6" />
                      </a>
                   </li>

--- a/src/components/common/HamburgerMenu.tsx
+++ b/src/components/common/HamburgerMenu.tsx
@@ -86,21 +86,21 @@ export default function HamburgerMenu({ onClose }: { onClose: () => void }) {
                </li>
                <li className="border-line-white-15 border-b">
                   <a
-                     href="https://www.youtube.com/"
+                     href="https://open.kakao.com/o/sWS3f0Th"
                      target="_blank"
                      rel="noopener noreferrer"
                   >
-                     유튜브
+                     카카오톡
                      <GoArrowUpRight size={22} />
                   </a>
                </li>
                <li>
                   <a
-                     href="https://github.com/az0319h/idamstudio-web"
+                     href="https://www.youtube.com/"
                      target="_blank"
                      rel="noopener noreferrer"
                   >
-                     깃허브
+                     유튜브
                      <GoArrowUpRight size={22} />
                   </a>
                </li>


### PR DESCRIPTION
## 작업 개요
- 사용자가 보다 쉽게 상담 및 문의할 수 있도록 카카오톡 오픈채팅방 링크 추가
- 챗봇 상담 규칙 강화 (상담 일정 직접 예약 요청 시 올바른 안내 제공)

---

## 작업 상세 내용
- [x] `create-chat.action.ts`  
  - 상담 일정 자동 예약 관련 요청이 들어올 경우 → 카카오톡 오픈채팅/문의하기로 안내하도록 규칙 추가
- [x] `contact/page.tsx`  
  - 기존 깃허브 링크 → 카카오톡 오픈채팅 링크로 교체
- [x] `Footer.tsx`  
  - 하단 메뉴에 카카오톡 오픈채팅 링크 반영
- [x] `HamburgerMenu.tsx`  
  - 모바일 메뉴에 카카오톡 오픈채팅 링크 반영

---

## 수정한 파일
- `src/api/create-chat.action.ts`
- `src/app/(with-same-header)/contact/page.tsx`
- `src/components/common/Footer.tsx`
- `src/components/common/HamburgerMenu.tsx`



---

## 기타 참고 사항
- 웹사이트 방문자가 **카카오톡 오픈채팅**으로 바로 문의 가능
- 상담 일정과 관련된 혼동 방지

