### PR TITLE
fix: WorkDetail 내장재 텍스트 수정 및 WorkSubImage 애니메이션 속도 조정

### DIFF
--- a/src/components/domains/work/WorkDetail.tsx
+++ b/src/components/domains/work/WorkDetail.tsx
@@ -2,7 +2,6 @@
 
 import { Project } from "@/lib/types";
 import Image from "next/image";
-import { RxSlash } from "react-icons/rx";
 import WorkDetailImagesGrid from "./WorkDetailImagesGrid";
 import { useNotification } from "@/context/NotificationContext";
 import { useIntersection } from "@/hooks";
@@ -141,7 +140,7 @@ export default function WorkDetail(props: Project) {
                               </p>
                            </div>
                            <div>
-                              <span>내장제</span>
+                              <span>내장재</span>
                               <p>
                                  {interior.map((item, index) => (
                                     <em key={index}>

--- a/src/components/domains/work/WorkSubImage.tsx
+++ b/src/components/domains/work/WorkSubImage.tsx
@@ -18,7 +18,7 @@ export default function WorkSubImage({
    return (
       <div
          ref={ref}
-         style={revealStyle(isVisible, index, 300)}
+         style={revealStyle(isVisible, index, 150)}
          className={span ? "md:col-span-2" : ""}
       >
          <Image


### PR DESCRIPTION
## 작업 개요

- `WorkDetail` 컴포넌트 내 텍스트 오타(`내장제 → 내장재`) 수정
- `WorkSubImage`의 이미지 등장 애니메이션 속도 조정으로 UX 개선

---

## 작업 상세 내용

- [x] 건축 상세 정보 영역에서 잘못 표기된 `내장제`를 `내장재`로 변경
- [x] `WorkSubImage.tsx` 내 `revealStyle` duration 값을 `300 → 150`으로 변경

---

## 수정한 파일
- `src/components/domains/work/WorkDetail.tsx`
- `src/components/domains/work/WorkSubImage.tsx`


## 기타 참고 사항
- 기능적 변경은 없으며, UI/UX 품질 개선에 집중한 마이너 수정 사항입니다.

