### PR TITLE
feat: 문의 폼 전송 성공 시 GA4 form_submit 이벤트 전송

### DIFF
--- a/src/components/domains/contact/ContactForm.tsx
+++ b/src/components/domains/contact/ContactForm.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { usePathname } from "next/navigation";
 import { useForm, type DefaultValues } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
@@ -9,6 +10,7 @@ import {
 import { ContactFormData, contactSchema } from "@/lib/schemas";
 import { createContact } from "@/api/create-contact.action";
 import { useNotification } from "@/context/NotificationContext";
+import { trackContactFormSubmit } from "@/lib/analytics/track-contact-submit";
 
 const defaultFormValues = {
    name: "",
@@ -31,13 +33,17 @@ export default function ContactForm() {
    });
 
    const { showNotification } = useNotification();
+   const pathname = usePathname();
 
    const consultationArea = watch("consultationArea");
 
    const onSubmit = async (data: ContactFormData) => {
       const result = await createContact(data);
       showNotification(result.message, result.success);
-      if (result.success) reset();
+      if (result.success) {
+         trackContactFormSubmit(pathname);
+         reset();
+      }
    };
 
    return (

--- a/src/lib/analytics/track-contact-submit.ts
+++ b/src/lib/analytics/track-contact-submit.ts
@@ -1,0 +1,20 @@
+function formLocationFromPathname(pathname: string | null): string {
+   if (!pathname || pathname === "/") return "home";
+   const trimmed = pathname.replace(/\/$/, "") || "/";
+   if (trimmed === "/contact") return "contact";
+   return trimmed.slice(1) || "unknown";
+}
+
+/** GA4: 문의 전송이 서버에서 성공했을 때 한 번 호출 */
+export function trackContactFormSubmit(pathname: string | null) {
+   if (typeof window === "undefined") return;
+   const { gtag } = window;
+   if (typeof gtag !== "function") return;
+
+   gtag("event", "form_submit", {
+      event_category: "lead",
+      event_label: "contact_form_submission",
+      form_location: formLocationFromPathname(pathname),
+      value: 1,
+   });
+}

--- a/src/types/gtag.d.ts
+++ b/src/types/gtag.d.ts
@@ -1,0 +1,8 @@
+export {};
+
+declare global {
+   interface Window {
+      dataLayer?: unknown[];
+      gtag?: (...args: unknown[]) => void;
+   }
+}


### PR DESCRIPTION
## 작업 개요

- 문의 폼 전송이 서버에서 성공했을 때 GA4에 `form_submit` 이벤트를 한 번 전송하도록 연동

---

## 작업 상세 내용

- [x] `ContactForm`에서 `createContact` 성공(`result.success === true`) 시에만 gtag 이벤트 호출
- [x] zod + react-hook-form 검증 통과 후에만 `onSubmit`이 실행되므로, 검증 실패 시에는 이벤트 미전송
- [x] `usePathname()`으로 `form_location` 파라미터 전달 (`home`: 랜딩 `/`, `contact`: `/contact`, 그 외 경로는 세그먼트 기준)
- [x] `window.gtag` 존재 여부 및 브라우저 환경에서만 호출 (SSR 안전)

---

## 수정한 파일

- `src/components/domains/contact/ContactForm.tsx`

## 새로 작성한 파일

- `src/lib/analytics/track-contact-submit.ts`
- `src/types/gtag.d.ts`

---

## 기타 참고 사항

- 전역 GA(gtag) 로드는 기존 `src/app/layout.tsx` 설정을 그대로 사용하며, 본 작업에서는 해당 파일을 변경하지 않음
- 배포 환경에 `NEXT_PUBLIC_GA_MEASUREMENT_ID`가 설정되어 있어야 프로덕션에서 측정됨
- GA4 **보고서 → 실시간 → 이벤트**에서 `form_submit` 및 `form_location` 확인 권장
- 개발자 도구 Network에서 `collect`(또는 `google-analytics.com/g/collect`) 요청으로 검증 가능