### PR TITLE
style(chatbot): 모바일(md 미만)에서 챗봇 UI 숨김

### DIFF
--- a/src/components/common/ChatBot.tsx
+++ b/src/components/common/ChatBot.tsx
@@ -41,6 +41,17 @@ export default function ChatBot() {
       }
    }, [isVisible]);
 
+   /** md 미만에서는 챗봇을 쓰지 않으므로, 뷰포트가 줄어들면 열린 패널·스크롤 잠금을 정리 */
+   useEffect(() => {
+      const mq = window.matchMedia("(min-width: 768px)");
+      const closeIfNarrow = () => {
+         if (!mq.matches) setIsOpen(false);
+      };
+      mq.addEventListener("change", closeIfNarrow);
+      closeIfNarrow();
+      return () => mq.removeEventListener("change", closeIfNarrow);
+   }, []);
+
    useEffect(() => {
       if (typeof window === "undefined") return;
 
@@ -131,7 +142,7 @@ export default function ChatBot() {
    };
 
    return (
-      <>
+      <div className="hidden md:block">
          {/* 챗봇 버튼 */}
          <AnimatePresence>
             {isVisible && (
@@ -263,6 +274,6 @@ export default function ChatBot() {
                </motion.div>
             )}
          </AnimatePresence>
-      </>
+      </div>
    );
 }


### PR DESCRIPTION
## 작업 개요

- 모바일 뷰포트에서는 AI 챗봇 UI를 노출하지 않고, 태블릿·데스크톱(`md` 이상)에서만 표시되도록 조정

---

## 작업 상세 내용

- [x] 챗봇 루트에 `hidden md:block` 적용 (768px 미만 비표시)
- [x] 뷰포트가 `md` 미만으로 줄어들 때 열린 패널 상태 정리 (`matchMedia`), 리사이즈 시 스크롤 잠금 잔여 이슈 방지

---

## 수정한 파일

- `src/components/common/ChatBot.tsx`

---


## 기타 참고 사항

- Tailwind 기본 `md` 브레이크포인트(768px)와 `globals.css`의 `--breakpoint-md`와 일치
- 모바일에서는 견적 문의(`/contact`), 푸터·카카오 등 기존 연락 채널만 사용하는 흐름에 맞춤

