### PR TITLE
fix(contact): iOS Safari 체크박스 표시 문제 해결

### DIFF
--- a/src/components/domains/contact/ContactConsentBlocks.tsx
+++ b/src/components/domains/contact/ContactConsentBlocks.tsx
@@ -1,24 +1,68 @@
 "use client";
 
 import Link from "next/link";
-import type { UseFormRegister, FieldErrors } from "react-hook-form";
+import type { UseFormRegister, FieldErrors, UseFormWatch } from "react-hook-form";
 import type { ContactFormValues } from "@/lib/schemas";
 
 type Props = {
    register: UseFormRegister<ContactFormValues>;
    errors: FieldErrors<ContactFormValues>;
+   watch: UseFormWatch<ContactFormValues>;
 };
 
-export default function ContactConsentBlocks({ register, errors }: Props) {
+function Checkbox({
+   register,
+   name,
+   checked,
+}: {
+   register: UseFormRegister<ContactFormValues>;
+   name: "privacyConsent" | "marketingConsent";
+   checked: boolean;
+}) {
+   return (
+      <div className="relative mt-0.5 h-5 w-5 shrink-0">
+         <input
+            type="checkbox"
+            {...register(name)}
+            className="absolute h-5 w-5 cursor-pointer opacity-0"
+         />
+         <div
+            className={`pointer-events-none flex h-5 w-5 items-center justify-center rounded-sm border transition-colors ${
+               checked
+                  ? "border-white bg-white"
+                  : "border-line-white-15 bg-transparent"
+            }`}
+         >
+            {checked && (
+               <svg
+                  className="h-3 w-3 text-black"
+                  viewBox="0 0 12 12"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+               >
+                  <path
+                     d="M2 6L5 9L10 3"
+                     stroke="currentColor"
+                     strokeWidth="2"
+                     strokeLinecap="round"
+                     strokeLinejoin="round"
+                  />
+               </svg>
+            )}
+         </div>
+      </div>
+   );
+}
+
+export default function ContactConsentBlocks({ register, errors, watch }: Props) {
+   const privacyChecked = watch("privacyConsent");
+   const marketingChecked = watch("marketingConsent");
+
    return (
       <>
          <div className="border-line-white-15 space-y-3 border p-4 md:p-5">
             <label className="flex cursor-pointer items-start gap-3">
-               <input
-                  type="checkbox"
-                  {...register("privacyConsent")}
-                  className="border-line-white-15 mt-1 h-4 w-4 shrink-0 rounded-sm border bg-black accent-white"
-               />
+               <Checkbox register={register} name="privacyConsent" checked={privacyChecked} />
                <span className="text-14-regular md:text-16-regular lg:text-18-regular leading-snug text-white">
                   [필수] 개인정보 수집·이용 동의
                </span>
@@ -54,11 +98,7 @@ export default function ContactConsentBlocks({ register, errors }: Props) {
 
          <div className="border-line-white-15 space-y-3 border p-4 md:p-5">
             <label className="flex cursor-pointer items-start gap-3">
-               <input
-                  type="checkbox"
-                  {...register("marketingConsent")}
-                  className="border-line-white-15 mt-1 h-4 w-4 shrink-0 rounded-sm border bg-black accent-white"
-               />
+               <Checkbox register={register} name="marketingConsent" checked={marketingChecked} />
                <span className="text-14-regular md:text-16-regular lg:text-18-regular leading-snug text-white">
                   [선택] 마케팅 정보 수신 동의
                </span>

--- a/src/components/domains/contact/ContactForm.tsx
+++ b/src/components/domains/contact/ContactForm.tsx
@@ -187,7 +187,7 @@ export default function ContactForm() {
                {errors.message && <p>{errors.message.message}</p>}
             </div>
 
-            <ContactConsentBlocks register={register} errors={errors} />
+            <ContactConsentBlocks register={register} errors={errors} watch={watch} />
 
             <div>
                <button


### PR DESCRIPTION
- 기본 checkbox accent-color 대신 커스텀 체크박스 컴포넌트 사용
- watch로 체크 상태 감시하여 SVG 체크마크 표시 제어
- 모든 브라우저에서 동일한 체크박스 UI 렌더링

Made-with: Cursor