### PR TITLE
feat(analytics): GA4 클릭 이벤트 추적 추가

### DIFF
--- a/src/app/(with-same-header)/contact/page.tsx
+++ b/src/app/(with-same-header)/contact/page.tsx
@@ -2,11 +2,18 @@
 import PageTitle from "@/components/common/PageTitle";
 import ContactForm from "@/components/domains/contact/ContactForm";
 import PageLayout from "@/components/layout/PageLayout";
+import { companyData } from "@/constants/companyData";
 import { useIntersection } from "@/hooks";
+import {
+   trackPhoneClick,
+   trackEmailClick,
+   trackKakaoChannelClick,
+} from "@/lib/analytics/track-click-events";
 import { revealStyle } from "@/utils";
 
 export default function ContactPage() {
    const { ref: sectionRef, isVisible } = useIntersection();
+   const telHref = `tel:${companyData.phone.replace(/-/g, "")}`;
 
    return (
       <PageLayout>
@@ -34,9 +41,10 @@ export default function ContactPage() {
                         href="https://open.kakao.com/o/sWS3f0Th"
                         target="_blank"
                         rel="noopener noreferrer"
+                        onClick={trackKakaoChannelClick}
                         className="link-underline"
                      >
-                        카카오톡
+                        카카오톡 채널
                      </a>
                      <a
                         href="https://www.youtube.com/@%EC%9D%B4%EB%8B%B4%EA%B1%B4%EC%B6%95"
@@ -64,10 +72,22 @@ export default function ContactPage() {
                   </div>
                   <div>
                      <p>
-                        <em>010 7123 0261</em>
+                        <a
+                           href={telHref}
+                           onClick={trackPhoneClick}
+                           className="link-underline font-[inherit] not-italic"
+                        >
+                           {companyData.phone}
+                        </a>
                      </p>
                      <p className="break-words">
-                        idamstudio.doodream@gmail.com
+                        <a
+                           href={`mailto:${companyData.email}`}
+                           onClick={trackEmailClick}
+                           className="link-underline"
+                        >
+                           {companyData.email}
+                        </a>
                      </p>
                   </div>
                </li>

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { GoArrowUpRight } from "react-icons/go";
 import { Spectral } from "next/font/google";
 import { useIntersection } from "@/hooks";
+import { trackKakaoChannelClick } from "@/lib/analytics/track-click-events";
 import { revealStyle } from "@/utils";
 const spectral = Spectral({
    subsets: ["latin"],
@@ -66,9 +67,10 @@ export default function Footer() {
                         href="https://open.kakao.com/o/sWS3f0Th"
                         target="_blank"
                         rel="noopener noreferrer"
+                        onClick={trackKakaoChannelClick}
                         className="group-hover:px-1 group-hover:text-white group-hover:transition-all group-hover:duration-300"
                      >
-                        카카오톡
+                        카카오톡 채널
                         <GoArrowUpRight size={22} className="md:size-6" />
                      </a>
                   </li>

--- a/src/components/common/HamburgerMenu.tsx
+++ b/src/components/common/HamburgerMenu.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { motion } from "framer-motion";
 import { GoArrowUpRight } from "react-icons/go";
+import { trackKakaoChannelClick } from "@/lib/analytics/track-click-events";
 export default function HamburgerMenu({ onClose }: { onClose: () => void }) {
    return (
       <motion.div
@@ -88,8 +89,9 @@ export default function HamburgerMenu({ onClose }: { onClose: () => void }) {
                      href="https://open.kakao.com/o/sWS3f0Th"
                      target="_blank"
                      rel="noopener noreferrer"
+                     onClick={trackKakaoChannelClick}
                   >
-                     카카오톡
+                     카카오톡 채널
                      <GoArrowUpRight size={22} />
                   </a>
                </li>

--- a/src/components/domains/root/LandingConsultationFlowSection.tsx
+++ b/src/components/domains/root/LandingConsultationFlowSection.tsx
@@ -4,6 +4,7 @@ import DefaultLayout from "@/components/layout/DefaultLayout";
 import { companyData } from "@/constants/companyData";
 import { landingConsultationSteps } from "@/constants/landingConsultation";
 import { useIntersection } from "@/hooks";
+import { trackPhoneClick } from "@/lib/analytics/track-click-events";
 import { revealStyle } from "@/utils";
 
 export default function LandingConsultationFlowSection() {
@@ -22,6 +23,7 @@ export default function LandingConsultationFlowSection() {
                </h2>
                <a
                   href={telHref}
+                  onClick={trackPhoneClick}
                   className="text-14-medium md:text-16-medium w-fit border-b border-black pb-0.5 transition-opacity hover:opacity-60"
                >
                   {companyData.phone}

--- a/src/lib/analytics/track-click-events.ts
+++ b/src/lib/analytics/track-click-events.ts
@@ -1,0 +1,35 @@
+/** GA4: 전화번호 클릭 시 호출 */
+export function trackPhoneClick() {
+   if (typeof window === "undefined") return;
+   const { gtag } = window;
+   if (typeof gtag !== "function") return;
+
+   gtag("event", "phone_click", {
+      event_category: "contact",
+      event_label: "phone_number",
+   });
+}
+
+/** GA4: 이메일 클릭 시 호출 */
+export function trackEmailClick() {
+   if (typeof window === "undefined") return;
+   const { gtag } = window;
+   if (typeof gtag !== "function") return;
+
+   gtag("event", "email_click", {
+      event_category: "contact",
+      event_label: "email_address",
+   });
+}
+
+/** GA4: 카카오톡 채널 클릭 시 호출 */
+export function trackKakaoChannelClick() {
+   if (typeof window === "undefined") return;
+   const { gtag } = window;
+   if (typeof gtag !== "function") return;
+
+   gtag("event", "kakao_channel_click", {
+      event_category: "contact",
+      event_label: "kakao_channel",
+   });
+}


### PR DESCRIPTION
## 작업 개요

- GA4 클릭 이벤트 추적 기능 추가 (전화, 이메일, 카카오톡 채널)

---

## 작업 상세 내용

- [x] `track-click-events.ts` 파일 생성 (phone_click, email_click, kakao_channel_click)
- [x] 전화번호 클릭 시 `phone_click` 이벤트 전송 (랜딩, /contact)
- [x] 이메일 클릭 시 `email_click` 이벤트 전송 (/contact)
- [x] 카카오톡 채널 클릭 시 `kakao_channel_click` 이벤트 전송 (/contact, Footer, HamburgerMenu)
- [x] "카카오톡" → "카카오톡 채널" 텍스트 통일 (3곳)
- [x] /contact 이메일을 mailto 링크로 변경 (클릭 시 메일 앱 실행)

---

## 수정한 파일

- `src/app/(with-same-header)/contact/page.tsx`
- `src/components/common/Footer.tsx`
- `src/components/common/HamburgerMenu.tsx`
- `src/components/domains/root/LandingConsultationFlowSection.tsx`

## 새로 작성한 파일

- `src/lib/analytics/track-click-events.ts`

---

## 기타 참고 사항

- PR 적용 후 GA4 실시간 보고서에서 이벤트 발화 확인 필요
- 추적 이벤트 목록: `form_submit`, `phone_click`, `email_click`, `kakao_channel_click`
- 주요 전환 이벤트는 GA4 관리자에서 "전환"으로 표시 설정 권장