### PR TITLE
chore(links): 카카오톡 채널 URL을 pf.kakao.com 공식 채널로 변경

### DIFF
--- a/src/app/(with-same-header)/contact/page.tsx
+++ b/src/app/(with-same-header)/contact/page.tsx
@@ -38,7 +38,7 @@ export default function ContactPage() {
                         인스타그램
                      </a>
                      <a
-                        href="https://open.kakao.com/o/sWS3f0Th"
+                        href="https://pf.kakao.com/_xfNQCX"
                         target="_blank"
                         rel="noopener noreferrer"
                         onClick={trackKakaoChannelClick}

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -64,7 +64,7 @@ export default function Footer() {
                   </li>
                   <li className="border-line-black-10 hover:border-line-white-15 group border-b transition-all duration-300 hover:bg-black">
                      <a
-                        href="https://open.kakao.com/o/sWS3f0Th"
+                        href="https://pf.kakao.com/_xfNQCX"
                         target="_blank"
                         rel="noopener noreferrer"
                         onClick={trackKakaoChannelClick}

--- a/src/components/common/HamburgerMenu.tsx
+++ b/src/components/common/HamburgerMenu.tsx
@@ -86,7 +86,7 @@ export default function HamburgerMenu({ onClose }: { onClose: () => void }) {
                </li>
                <li className="border-line-white-15 border-b">
                   <a
-                     href="https://open.kakao.com/o/sWS3f0Th"
+                     href="https://pf.kakao.com/_xfNQCX"
                      target="_blank"
                      rel="noopener noreferrer"
                      onClick={trackKakaoChannelClick}


### PR DESCRIPTION
open.kakao.com 오픈채팅 링크를 제거하고, 푸터·햄버거 메뉴·문의 페이지의
카카오톡 채널 바로가기를 https://pf.kakao.com/_xfNQCX 로 통일함.

Made-with: Cursor

## 작업 개요

- 사이트 내 카카오톡 채널 진입 URL을 오픈채팅(open.kakao.com)에서 공식 채널(pf.kakao.com)로 변경

---

## 작업 상세 내용

- [x] 푸터 카카오톡 채널 링크 URL 변경
- [x] 햄버거 메뉴 카카오톡 채널 링크 URL 변경
- [x] 문의(Contact) 페이지 카카오톡 채널 링크 URL 변경
- [x] 기존 GA4 `trackKakaoChannelClick` 등 클릭 추적 동작 유지 (링크만 교체)

---

## 수정한 파일

- `src/components/common/Footer.tsx`
- `src/components/common/HamburgerMenu.tsx`
- `src/app/(with-same-header)/contact/page.tsx`

---

## 새로 작성한 파일

- 없음

---

## 기타 참고 사항

- 변경 URL: `https://pf.kakao.com/_xfNQCX`
- 이전 URL: `https://open.kakao.com/o/sWS3f0Th` (오픈채팅)
